### PR TITLE
disable timers, teardown, and more garbage collection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2000,6 +2000,7 @@
                                                                                                 "repository-secrets.service"
                                                                                                 "secrets.service"
                                                                                            ] ;
+                                                                                        enable = false ;
                                                                                         serviceConfig =
                                                                                             {
                                                                                                 ExecStart = "${ pkgs.coreutils }/bin/true" ;
@@ -2120,6 +2121,7 @@
                                                                     {
                                                                         setup =
                                                                             {
+                                                                                enable = false ;
                                                                                 timerConfig =
                                                                                     {
                                                                                         OnCalendar = config.personal.frequency.setup ;
@@ -2127,6 +2129,7 @@
                                                                             } ;
                                                                         teardown =
                                                                             {
+                                                                                enable = false ;
                                                                                 timerConfig =
                                                                                     {
                                                                                         OnCalendar = config.personal.frequency.teardown ;
@@ -2773,7 +2776,9 @@
                                                                                                                                 git -C /var/lib/workspaces/${ epoch }/repository/personal checkout "scratch/$( uuidgen )"
                                                                                                                                 git -C /var/lib/workspaces/${ epoch }/repository/secrets checkout origin/main
                                                                                                                                 git -C /var/lib/workspaces/${ epoch }/repository/secrets checkout -b "scratch/$( uuidgen )"
+                                                                                                                                df -h
                                                                                                                                 nix-collect-garbage
+                                                                                                                                df -h
                                                                                                                                 if nixos-rebuild build-vm-with-bootloader --update-input personal --update-input secrets --flake /var/lib/workspaces/${ epoch }/repository/private
                                                                                                                                 then
                                                                                                                                     if LD_LIBRARY_PATH=${ pkgs.e2fsprogs }/bin result/bin/run-nixos-vm


### PR DESCRIPTION
teardown was causing problems on second boot.  also garbage collection is good because build-vm-with-bootloader takes a lot of space