### PR TITLE
cleanup old and deprecated systemd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1443,6 +1443,11 @@
                                                                         xkbVariant = "" ;
                                                                     } ;
                                                             } ;
+                                                              system.activationScripts.cleanupRemovedUnits.text = ''
+                                                                echo "Cleaning up removed systemd units..."
+                                                                find /etc/systemd/system -name 'stash-setup.*' -exec rm -v {} +
+                                                                systemctl daemon-reload
+                                                              '';
                                                         systemd =
                                                             let
                                                                 post-commit =


### PR DESCRIPTION
i found out that removing systemd services and timers does not actually remove them from the computer.  this script will hopefully do that.